### PR TITLE
LPS-114512 Invalid search filter when using Organizations in Segments Criteria Builder

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/criteria/contributor/UserOrganizationSegmentsCriteriaContributor.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/criteria/contributor/UserOrganizationSegmentsCriteriaContributor.java
@@ -80,7 +80,8 @@ public class UserOrganizationSegmentsCriteriaContributor
 			for (Organization organization : organizations) {
 				sb.append("'");
 				sb.append(organization.getOrganizationId());
-				sb.append("', ");
+				sb.append("'");
+				sb.append(", ");
 			}
 
 			if (!organizations.isEmpty()) {


### PR DESCRIPTION
Hi @Brianchandotcom, this commit is really needed since we're getting rid of the last comma in case there are no more organizations 